### PR TITLE
Remove stopservices function

### DIFF
--- a/prox_config_backup.sh
+++ b/prox_config_backup.sh
@@ -164,13 +164,6 @@ function compressandarchive {
     cp $_filename_final $_bdir/
 }
 
-function stopservices {
-    # stop host services
-    for i in pve-cluster pvedaemon vz qemu-server; do systemctl stop $i ; done
-    # give them a moment to finish
-    sleep 10s
-}
-
 function startservices {
     # restart services
     for i in qemu-server vz pvedaemon pve-cluster; do systemctl start $i ; done
@@ -188,9 +181,6 @@ fi
 description
 are-we-root-abort-if-not
 check-num-backups
-
-# We don't need to stop services, but you can do that if you wish
-#stopservices
 
 copyfilesystem
 


### PR DESCRIPTION
## Summary
- remove the unused `stopservices` function from `prox_config_backup.sh`

## Testing
- `bash -n prox_config_backup.sh`
- `shellcheck prox_config_backup.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c0ab722c832a8cc5049d22471b6a